### PR TITLE
parseUrl: reduced allocations to get a 1.5x speedup

### DIFF
--- a/src/webby/urls.nim
+++ b/src/webby/urls.nim
@@ -122,7 +122,7 @@ proc parseUrl*(s: string): Url =
       if i == 0:
         raise newException(CatchableError, "Missing protocol scheme in URL")
       result.scheme = toLowerAscii(s[0 ..< i])
-      s.delete(0 .. i)
+      s.delete(0, i)
       break
     else:
       # Invalid character


### PR DESCRIPTION
Unnecessary heap allocations were taking around 35% of the time to parse `foo://admin:hunter1@example.com:8042/over/there?name=ferret#nose`.