### PR TITLE
Speed up URL parsing

### DIFF
--- a/src/webby/httpheaders.nim
+++ b/src/webby/httpheaders.nim
@@ -5,12 +5,8 @@ type HttpHeaders* = distinct seq[(string, string)]
 converter toBase*(headers: var HttpHeaders): var seq[(string, string)] =
   headers.distinctBase
 
-when (NimMajor, NimMinor, NimPatch) >= (1, 4, 8):
-  converter toBase*(params: HttpHeaders): lent seq[(string, string)] =
-    params.distinctBase
-else: # Older versions
-  converter toBase*(params: HttpHeaders): seq[(string, string)] =
-    params.distinctBase
+converter toBase*(params: HttpHeaders): lent seq[(string, string)] =
+  params.distinctBase
 
 converter toWebby*(headers: seq[(string, string)]): HttpHeaders =
   headers.HttpHeaders

--- a/src/webby/queryparams.nim
+++ b/src/webby/queryparams.nim
@@ -5,12 +5,8 @@ type QueryParams* = distinct seq[(string, string)]
 converter toBase*(params: var QueryParams): var seq[(string, string)] =
   params.distinctBase
 
-when (NimMajor, NimMinor, NimPatch) >= (1, 4, 8):
-  converter toBase*(params: QueryParams): lent seq[(string, string)] =
-    params.distinctBase
-else: # Older versions
-  converter toBase*(params: QueryParams): seq[(string, string)] =
-    params.distinctBase
+converter toBase*(params: QueryParams): lent seq[(string, string)] =
+  params.distinctBase
 
 proc encodeQueryComponent*(s: string): string =
   ## Similar to encodeURIComponent, however query parameter spaces should

--- a/src/webby/urls.nim
+++ b/src/webby/urls.nim
@@ -128,10 +128,7 @@ proc parseUrl*(s: string): Url =
       if i == 0:
         raise newException(CatchableError, "Missing protocol scheme in URL")
       result.scheme = toLowerAscii(s[0 ..< i])
-      when NimMajor > 1 or (NimMajor == 1 and NimMinor >= 6):
-        s.delete(0 .. i)
-      else:
-        s.delete(0, i)
+      s.delete(0 .. i)
       break
     else:
       # Invalid character

--- a/src/webby/urls.nim
+++ b/src/webby/urls.nim
@@ -78,15 +78,28 @@ proc encodeURI*(s: string): string =
 proc parseSearch*(search: string): QueryParams =
   ## Parses the search part into strings pairs
   ## ``"name=&age&legs=4" -> @[("name", ""), ("age", ""), ("legs", "4")]``
-  for pairStr in search.split('&'):
+  var pairStart = 0
+  while true:
     let
-      pair = pairStr.split('=', 1)
+      pairEndFind = search.find('&', start = pairStart)
+      pairEnd =
+        if pairEndFind >= 0: pairEndFind
+        else: search.len
+      eqIdx =
+        if pairEnd <= pairStart: -1
+        else: search.find('=', start = pairStart, last = pairEnd - 1)
       kv =
-        if pair.len == 2:
-          (decodeQueryComponent(pair[0]), decodeQueryComponent(pair[1]))
+        if eqIdx >= 0:
+          (
+            decodeQueryComponent(search[pairStart ..< eqIdx]),
+            decodeQueryComponent(search[eqIdx + 1 ..< pairEnd])
+          )
         else:
-          (decodeQueryComponent(pair[0]), "")
+          (decodeQueryComponent(search[pairStart ..< pairEnd]), "")
     result.add(kv)
+    if pairEnd == search.len:
+      break
+    pairStart = pairEnd + 1
 
 proc parseUrl*(s: string): Url =
   var s = s
@@ -94,9 +107,8 @@ proc parseUrl*(s: string): Url =
   # Fragment
   let fragmentIdx = s.find('#')
   if fragmentIdx >= 0:
-    var parts = s.split('#', maxsplit = 1)
-    result.fragment = decodeURIComponent(parts[1])
-    s = move parts[0]
+    result.fragment = decodeURIComponent(s[fragmentIdx + 1 .. ^1])
+    s.setLen(fragmentIdx)
 
   if containsControlByte(s):
     raise newException(CatchableError, "Invalid control character in URL")
@@ -115,23 +127,25 @@ proc parseUrl*(s: string): Url =
     elif c == ':':
       if i == 0:
         raise newException(CatchableError, "Missing protocol scheme in URL")
-      var parts = s.split(':', maxsplit = 1)
-      result.scheme = toLowerAscii(parts[0])
-      s = move parts[1]
+      result.scheme = toLowerAscii(s[0 ..< i])
+      when NimMajor > 1 or (NimMajor == 1 and NimMinor >= 6):
+        s.delete(0 .. i)
+      else:
+        s.delete(0, i)
       break
     else:
       # Invalid character
       break
 
   # Query
-  if '?' in s:
-    if s[^1] == '?' and s.count('?') == 1:
+  let queryIdx = s.find('?')
+  if queryIdx >= 0:
+    if queryIdx == s.high:
       # result.forceQuery = true
-      s.setLen(s.len - 1)
+      discard
     else:
-      var parts = s.split('?', maxsplit = 1)
-      result.query = parseSearch(parts[1])
-      s = move parts[0]
+      result.query = parseSearch(s[queryIdx + 1 .. ^1])
+    s.setLen(queryIdx)
 
   # Opaque
   if not s.startsWith('/') and result.scheme != "":
@@ -167,10 +181,12 @@ proc parseUrl*(s: string): Url =
             CatchableError,
             "Invalid character in URL authority"
           )
-      var parts = authority.split(':', maxsplit = 1)
-      result.username = decodeURIComponent(parts[0])
-      if parts.len > 1:
-        result.password = decodeURIComponent(parts[1])
+      let colonIdx = authority.find(':')
+      if colonIdx >= 0:
+        result.username = decodeURIComponent(authority[0 ..< colonIdx])
+        result.password = decodeURIComponent(authority[colonIdx + 1 .. ^1])
+      else:
+        result.username = decodeURIComponent(authority)
 
     # Host
     var host: string
@@ -194,10 +210,12 @@ proc parseUrl*(s: string): Url =
       if host.len > closingIdx + 2 and host[closingIdx + 1] == ':':
         result.port = host[closingIdx + 2 .. ^1]
     else:
-      var parts = host.rsplit(':', maxsplit = 1)
-      result.hostname = decodeURIComponent(parts[0])
-      if parts.len > 1:
-        result.port = move parts[1]
+      let colonIdx = host.rfind(':')
+      if colonIdx >= 0:
+        result.hostname = decodeURIComponent(host[0 ..< colonIdx])
+        result.port = host[colonIdx + 1 .. ^1]
+      else:
+        result.hostname = decodeURIComponent(host)
     for c in result.port:
       if c notin {'0' .. '9'}:
         raise newException(

--- a/tests/bench_urls.nim
+++ b/tests/bench_urls.nim
@@ -1,0 +1,150 @@
+import benchy, webby
+
+# Run with:
+#   nim r -d:release tests/bench_urls.nim
+
+const
+  BenchRuns = 30
+  CanonicalRounds = 100_000
+  FixedCorpusRounds = 4_000
+  SyntheticCorpusRounds = 100
+  SearchRounds = 8_000
+
+  CanonicalUrl = "foo://admin:hunter1@example.com:8042/over/there?name=ferret#nose"
+
+  CanonicalUrls = [
+    CanonicalUrl
+  ]
+
+  FixedUrls = [
+    CanonicalUrl,
+    "/over/there?name=ferret",
+    "?name=ferret&age=12&leg=1&leg=2&leg=3&leg=4",
+    "google.com/a/path?id=3",
+    "//example.com?q=foo#heading1",
+    "https://example.com?site=https%3A%2F%2Fnim-lang.org&nothing=&specials=%0A%09%08%0D%22%2B%26%3D",
+    "http://localhost:8080/p2/foo%2Band%2Bother%2Bstuff",
+    "file:///C:/FooBar/Baz.txt",
+    "mailto:webmaster@golang.org",
+    "magnet:?xt=urn%3Abtih%3Ac12fe1c06bba254a9dc9f519b335aa7c1367a88a",
+    "http://[fe80::1%25en0]:8080/",
+    "tcp://[2020::2020:20:2020:2020%25Windows%20Loves%20Spaces]:2020",
+    "http://j%40ne:password@google.com/p@th?q=@go",
+    "*",
+    "///threeslashes",
+    "http://www.google.com/?foo=bar?"
+  ]
+
+proc makeSyntheticUrls(): seq[string] =
+  const
+    schemes = ["http", "https"]
+    hosts = ["example.com", "api.service.local", "192.168.0.1", "[fe80::1]"]
+    paths = [
+      "/",
+      "/api/v1/items",
+      "/files/report%202026.csv",
+      "/nested/a/b/c",
+      "/search"
+    ]
+    queries = [
+      "",
+      "?q=nim",
+      "?name=ferret&age=12",
+      "?leg=1&leg=2&leg=3&leg=4",
+      "?redirect=https%3A%2F%2Fnim-lang.org&empty=",
+      "?encoded=%E2%98%BA&space=hello+world"
+    ]
+    fragments = ["", "#top", "#section%202"]
+    relatives = [
+      "/relative/path?x=1",
+      "relative/path",
+      "../up/one?name=value",
+      "?only=query&repeated=1&repeated=2",
+      "//scheme-relative.example/path",
+      "*"
+    ]
+
+  for scheme in schemes:
+    for host in hosts:
+      for path in paths:
+        for query in queries:
+          for fragment in fragments:
+            result.add scheme & "://" & host & path & query & fragment
+
+  for url in relatives:
+    result.add url
+
+proc makeSearches(): seq[string] =
+  const
+    keys = ["name", "age", "leg", "encoded", "empty", "redirect", "space"]
+    values = [
+      "ferret",
+      "12",
+      "1",
+      "%E2%98%BA",
+      "",
+      "https%3A%2F%2Fnim-lang.org",
+      "hello+world"
+    ]
+
+  for i in 0 ..< 256:
+    var search: string
+    for j in 0 .. i mod keys.len:
+      if search.len > 0:
+        search.add '&'
+      search.add keys[j]
+      search.add '='
+      search.add values[(i + j) mod values.len]
+    result.add search
+
+let
+  SyntheticUrls = makeSyntheticUrls()
+  Searches = makeSearches()
+
+var benchSink: int
+
+proc consume(url: Url): int {.noinline.} =
+  result = result xor url.scheme.len
+  result = result xor (url.username.len shl 1)
+  result = result xor (url.password.len shl 2)
+  result = result xor (url.hostname.len shl 3)
+  result = result xor (url.port.len shl 4)
+  result = result xor (url.opaque.len shl 5)
+  result = result xor (url.path.len shl 6)
+  result = result xor (url.fragment.len shl 7)
+  result = result xor (url.query.len shl 8)
+
+proc consume(query: QueryParams): int {.noinline.} =
+  for (key, value) in query:
+    result = result xor key.len
+    result = result xor (value.len shl 4)
+
+proc parseUrls(urls: openArray[string], rounds: int) {.noinline.} =
+  var checksum: int
+  for r in 0 ..< rounds:
+    checksum = checksum xor r
+    for url in urls:
+      checksum = checksum xor consume(parseUrl(url))
+  benchSink = benchSink xor checksum
+
+proc parseSearches(searches: openArray[string], rounds: int) {.noinline.} =
+  var checksum: int
+  for r in 0 ..< rounds:
+    checksum = checksum xor r
+    for search in searches:
+      checksum = checksum xor consume(parseSearch(search))
+  benchSink = benchSink xor checksum
+
+timeIt "parseUrl canonical complex", BenchRuns:
+  parseUrls(CanonicalUrls, CanonicalRounds)
+
+timeIt "parseUrl fixed corpus", BenchRuns:
+  parseUrls(FixedUrls, FixedCorpusRounds)
+
+timeIt "parseUrl synthetic corpus", BenchRuns:
+  parseUrls(SyntheticUrls, SyntheticCorpusRounds)
+
+timeIt "parseSearch synthetic corpus", BenchRuns:
+  parseSearches(Searches, SearchRounds)
+
+keep benchSink

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -70,6 +70,13 @@ block:
   doAssert $url.query == "name=&age=&legs=4"
 
 block:
+  let params = parseSearch("a=1&&b=2&")
+  var pairs: seq[(string, string)]
+  for pair in params:
+    pairs.add(pair)
+  doAssert pairs == @[("a", "1"), ("", ""), ("b", "2"), ("", "")]
+
+block:
   let test = "google.com/a/path?id=3"
   let url = parseUrl(test)
   doAssert url.path == "google.com/a/path"

--- a/webby.nimble
+++ b/webby.nimble
@@ -5,4 +5,4 @@ license     = "MIT"
 
 srcDir = "src"
 
-requires "nim >= 1.2.2"
+requires "nim >= 2.0.0"


### PR DESCRIPTION
## Summary
- mark Webby as Nim 2+ in webby.nimble and remove old Nim 1.x compatibility branches
- add a Benchy URL benchmark suite covering one canonical complex URL, a fixed corpus, a synthetic URL corpus, and parseSearch workloads
- reduce parseUrl and parseSearch temporary allocations by replacing split/rsplit calls with index-based parsing
- add regression coverage for empty/trailing query pairs preserved by parseSearch

## Before / after benchmark
Command: nim r -d:release tests/bench_urls.nim
Environment: Windows amd64, Nim 2.2.4, mm:orc, threads:on

| Benchmark | Before avg | After avg | Speedup | Less time |
| --- | ---: | ---: | ---: | ---: |
| parseUrl canonical complex | 250.617 ms | 174.232 ms | 1.44x | 30.5% |
| parseUrl fixed corpus | 85.165 ms | 60.667 ms | 1.40x | 28.8% |
| parseUrl synthetic corpus | 149.674 ms | 103.521 ms | 1.45x | 30.8% |
| parseSearch synthetic corpus | 3353.673 ms | 2263.414 ms | 1.48x | 32.5% |

## Verification
- nim check src/webby.nim
- nim check tests/tests.nim
- nim r tests/tests.nim
- nim r -d:release tests/fuzz.nim
- nim r -d:release tests/bench_urls.nim
- git diff --check